### PR TITLE
Fix compile error on newer P4C compiler

### DIFF
--- a/p4src/main.p4
+++ b/p4src/main.p4
@@ -30,7 +30,7 @@ control IngressPipeImpl (inout parsed_headers_t hdr,
                          inout standard_metadata_t standard_metadata) {
 
     action drop() {
-        mark_to_drop();
+        mark_to_drop(standard_metadata);
     }
 
     action set_output_port(port_num_t port_num) {
@@ -304,7 +304,7 @@ control EgressPipeImpl (inout parsed_headers_t hdr,
 
         if (local_metadata.is_multicast == true
              && standard_metadata.ingress_port == standard_metadata.egress_port) {
-            mark_to_drop();
+            mark_to_drop(standard_metadata);
         }
     }
 }


### PR DESCRIPTION
Fix compile error on newer P4C compiler.

In newer v1model.p4 `mark_to_drop` now requires standard_metadata as input variable.

https://github.com/p4lang/p4c/blob/master/p4include/v1model.p4